### PR TITLE
Apply dateutil.parser for varied datetime string format

### DIFF
--- a/exitnaver/__init__.py
+++ b/exitnaver/__init__.py
@@ -10,6 +10,7 @@ from BeautifulSoup import BeautifulSoup
 from html2text import html2text
 from HTMLParser import HTMLParser
 from time import strftime, strptime
+from dateutil.parser import parse
 
 def make_room(username):
     try:
@@ -42,7 +43,7 @@ def main(username):
             except:
                 continue
 
-            date = strptime(post.p.text, "%Y/%m/%d %H:%M")
+            date = parse(post.p.text).timetuple()
             filename = "{0}-{1}.md".format(strftime("%Y-%m-%d", date), title).replace('/', '.')
 
             archive = os.path.join(username, strftime("%Y-%m", date))

--- a/exitnaver/__init__.py
+++ b/exitnaver/__init__.py
@@ -3,14 +3,14 @@
 import itertools
 import os
 import re
-import sys
 import urllib2
 
 from BeautifulSoup import BeautifulSoup
 from html2text import html2text
 from HTMLParser import HTMLParser
-from time import strftime, strptime
+from time import strftime
 from dateutil.parser import parse
+
 
 def make_room(username):
     try:
@@ -20,8 +20,10 @@ def make_room(username):
         print "Directory {0} already exists. Please remove the directory first.".format(username)
         return False
 
+
 def main(username):
-    if not make_room(username): return False
+    if not make_room(username):
+        return False
 
     postnum = re.compile('post_\d*')
     postid = re.compile('post-view*')

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     ],
     license='GPL',
     packages=['exitnaver'],
-    install_requires=['html2text', 'BeautifulSoup'],
+    install_requires=['html2text', 'BeautifulSoup', 'python-dateutil'],
     scripts=['bin/exitnaver']
 )


### PR DESCRIPTION
Naver blog changed its datetime string format, and I can't ensure that they will preserve their format till (near) future.
So I applied `python-dateutil` for it.
